### PR TITLE
Update GH Pages workflow

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,23 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 18
+    - name: Install dependencies
+      run: npm install
+    - name: Build
+      run: npm run build -- --output-path pages
+    - name: Deploy
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./pages


### PR DESCRIPTION
## Summary
- output release build to `pages` folder
- deploy `pages` folder to GitHub Pages

## Testing
- `npm install`
- `npm run build -- --output-path pages` *(fails: error:0308010C:digital envelope routines::unsupported)*

------
https://chatgpt.com/codex/tasks/task_e_68430ee16bd0832a95a88d637bed7cd0